### PR TITLE
BugFix: allow shortcuts to be updated when active profile changes

### DIFF
--- a/src/ShortcutsManager.cpp
+++ b/src/ShortcutsManager.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2021 by Piotr Wilczynski - delwing@gmail.com            *
+ *   Copyright (C) 2021 by Stephen Lyons - slysven@virginmdedia.com        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,6 +19,24 @@
  ***************************************************************************/
 
 #include "ShortcutsManager.h"
+
+ShortcutsManager::~ShortcutsManager()
+{
+    QMutableMapIterator<QString, QKeySequence*> itShortcut(shortcuts);
+    while (itShortcut.hasNext()) {
+        itShortcut.next();
+        auto pKeySequence = itShortcut.value();
+        delete pKeySequence;
+        itShortcut.remove();
+    }
+    QMutableMapIterator<QString, QKeySequence*> itDefault(defaults);
+    while (itDefault.hasNext()) {
+        itDefault.next();
+        auto pKeySequence = itDefault.value();
+        delete pKeySequence;
+        itDefault.remove();
+    }
+}
 
 void ShortcutsManager::registerShortcut(const QString& key, const QString& translation, QKeySequence* sequence)
 {

--- a/src/ShortcutsManager.h
+++ b/src/ShortcutsManager.h
@@ -3,6 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2021 by Piotr Wilczynski - delwing@gmail.com            *
+ *   Copyright (C) 2021 by Stephen Lyons - slysven@virginmdedia.com        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -27,11 +28,14 @@
 #include <QShortcut>
 #include "post_guard.h"
 
-class ShortcutsManager : public QObject {
+class ShortcutsManager : public QObject
+{
 
     Q_OBJECT
 
 public:
+    ~ShortcutsManager();
+
     void registerShortcut(const QString&, const QString&, QKeySequence*);
     QStringListIterator iterator();
     void setShortcut(const QString&, QKeySequence*);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2307,46 +2307,62 @@ void mudlet::assignKeySequences()
     mMenuVisibleState = !(mMenuBarVisibility == visibleNever || (mMenuBarVisibility == visibleOnlyWithoutLoadedProfile && mHostManager.getHostCount()));
     if (!mMenuVisibleState.value()) {
         // The menu is hidden so wire the QKeySequences directly to the slots:
+
+        // If there was a shortcut then get rid of it - no need for a
+        // call to "disconnect(...)" as that happens on deletion and since it
+        // is okay to delete a nullptr there is no need to include a non-null
+        // test first:
+        delete triggersShortcut.data();
         triggersShortcut = new QShortcut(triggersKeySequence, this);
         connect(triggersShortcut.data(), &QShortcut::activated, this, &mudlet::show_editor_dialog);
         dactionScriptEditor->setShortcut(QKeySequence());
 
+        delete showMapShortcut.data();
         showMapShortcut = new QShortcut(showMapKeySequence, this);
         connect(showMapShortcut.data(), &QShortcut::activated, this, &mudlet::slot_mapper);
         dactionShowMap->setShortcut(QKeySequence());
 
+        delete inputLineShortcut.data();
         inputLineShortcut = new QShortcut(inputLineKeySequence, this);
         connect(inputLineShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_compact_input_line);
         dactionInputLine->setShortcut(QKeySequence());
 
+        delete optionsShortcut.data();
         optionsShortcut = new QShortcut(optionsKeySequence, this);
         connect(optionsShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_options_dialog);
         dactionOptions->setShortcut(QKeySequence());
 
+        delete notepadShortcut.data();
         notepadShortcut = new QShortcut(notepadKeySequence, this);
         connect(notepadShortcut.data(), &QShortcut::activated, this, &mudlet::slot_notes);
         dactionNotepad->setShortcut(QKeySequence());
 
+        delete packagesShortcut.data();
         packagesShortcut = new QShortcut(packagesKeySequence, this);
         connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_package_manager);
         dactionPackageManager->setShortcut(QKeySequence());
 
+        delete modulesShortcut.data();
         modulesShortcut = new QShortcut(packagesKeySequence, this);
         connect(modulesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_module_manager);
         dactionModuleManager->setShortcut(QKeySequence());
 
+        delete multiViewShortcut.data();
         multiViewShortcut = new QShortcut(multiViewKeySequence, this);
         connect(multiViewShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_multi_view);
         dactionMultiView->setShortcut(QKeySequence());
 
+        delete connectShortcut.data();
         connectShortcut = new QShortcut(connectKeySequence, this);
         connect(connectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_connection_dialog);
         dactionConnect->setShortcut(QKeySequence());
 
+        delete disconnectShortcut.data();
         disconnectShortcut = new QShortcut(disconnectKeySequence, this);
         connect(disconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_disconnect);
         dactionDisconnect->setShortcut(QKeySequence());
 
+        delete reconnectShortcut.data();
         reconnectShortcut = new QShortcut(reconnectKeySequence, this);
         connect(reconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_reconnect);
         dactionReconnect->setShortcut(QKeySequence());


### PR DESCRIPTION
Without the uses of the `delete`s it is possible to get multiple `QShortcut`s defined and connected to various `mudlet` class slot methods which will then stop them working and trigger (at least in the KDE Plasma Desktop Environment) warnings about "Ambiguous keyboard shortcuts".

Also add a missing destructor to the ShortcutsManager class, this is desirable as it otherwise will not clean up some memory that will have been previously allocated with `new`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>