### PR TITLE
Fix: revise/improve new map_label form/dialogue

### DIFF
--- a/src/ui/map_label.ui
+++ b/src/ui/map_label.ui
@@ -17,66 +17,28 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Map label</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_main">
    <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QFrame" name="frame_top">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="title">
-      <string>Map label</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="4" column="2">
-       <widget class="QToolButton" name="toolButton_fontPick">
+     <layout class="QGridLayout" name="gridLayout_frame_top">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_type">
         <property name="text">
-         <string>...</string>
+         <string>Type:</string>
         </property>
-       </widget>
-      </item>
-      <item row="7" column="1" colspan="2">
-       <widget class="QPushButton" name="pushButton_bgColor">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_image">
-        <property name="text">
-         <string>Image:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="label_bg">
-        <property name="text">
-         <string>Background:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="checkBox_stretchImage">
-        <property name="text">
-         <string>Stretch image</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_font">
-        <property name="text">
-         <string>Font:</string>
+        <property name="buddy">
+         <cstring>comboBox_type</cstring>
         </property>
        </widget>
       </item>
@@ -94,37 +56,13 @@
         </item>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_type">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_image">
         <property name="text">
-         <string>Type:</string>
+         <string>Image:</string>
         </property>
-       </widget>
-      </item>
-      <item row="10" column="1">
-       <widget class="QCheckBox" name="checkBox_scaling">
-        <property name="toolTip">
-         <string>If deselected the label will have the same size when you zoom in and out in the mapper. If it is selected the label will scale when you zoom the mapper.</string>
-        </property>
-        <property name="text">
-         <string>Scale with zoom</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_text">
-        <property name="text">
-         <string>Label text:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1" colspan="2">
-       <widget class="QLineEdit" name="lineEdit_text">
-        <property name="placeholderText">
-         <string>My Label</string>
+        <property name="buddy">
+         <cstring>toolButton_imagePick</cstring>
         </property>
        </widget>
       </item>
@@ -142,7 +80,89 @@
         </property>
        </widget>
       </item>
-      <item row="9" column="1" colspan="2">
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="checkBox_stretchImage">
+        <property name="text">
+         <string>Stretch image</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_text">
+        <property name="text">
+         <string>Label text:</string>
+        </property>
+        <property name="buddy">
+         <cstring>lineEdit_text</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="2">
+       <widget class="QLineEdit" name="lineEdit_text">
+        <property name="placeholderText">
+         <string>My Label</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_font">
+        <property name="text">
+         <string>Font:</string>
+        </property>
+        <property name="buddy">
+         <cstring>toolButton_fontPick</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="lineEdit_font">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QToolButton" name="toolButton_fontPick">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_fg">
+        <property name="text">
+         <string>Foreground:</string>
+        </property>
+        <property name="buddy">
+         <cstring>pushButton_fgColor</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="2">
+       <widget class="QPushButton" name="pushButton_fgColor">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_bg">
+        <property name="text">
+         <string>Background:</string>
+        </property>
+        <property name="buddy">
+         <cstring>pushButton_bgColor</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1" colspan="2">
+       <widget class="QPushButton" name="pushButton_bgColor">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1" colspan="2">
        <widget class="QComboBox" name="comboBox_position">
         <item>
          <property name="text">
@@ -156,31 +176,26 @@
         </item>
        </widget>
       </item>
-      <item row="4" column="1">
-       <widget class="QLineEdit" name="lineEdit_font">
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="label_position">
         <property name="text">
          <string>Position:</string>
         </property>
-       </widget>
-      </item>
-      <item row="6" column="1" colspan="2">
-       <widget class="QPushButton" name="pushButton_fgColor">
-        <property name="text">
-         <string/>
+        <property name="buddy">
+         <cstring>comboBox_position</cstring>
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_fg">
+      <item row="8" column="1">
+       <widget class="QCheckBox" name="checkBox_scaling">
+        <property name="toolTip">
+         <string>If deselected the label will have the same size when you zoom in and out in the mapper. If it is selected the label will scale when you zoom the mapper.</string>
+        </property>
         <property name="text">
-         <string>Foreground:</string>
+         <string>Scale with zoom</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -188,7 +203,7 @@
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_middle">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -201,16 +216,16 @@
     </spacer>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget_bottom" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QHBoxLayout" name="horizontalLayout_bottom">
       <item>
-       <spacer name="horizontalSpacer">
+       <spacer name="horizontalSpacer_bottom">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>


### PR DESCRIPTION
Reorder the elements in a `QGridLayout` so that they are in a logical order.

Convert a `QGroupBox` to a `QFrame` and move it's title element to the whole "dialogue" (which otherwise would display the default "Form" to the end-user!)

Add buddy definitions to all the labels to their corresponding control widgets.

Give more meaningful (object) names to some objects that otherwise have the Qt defaults of: `widgetClassWithoutLeadingQ(_numeric_suffix_if_more_than_one)`.

Consideration ought to be given to converting the lower 2 push-button composite widget to be the more usual `QDialogButtonBox` that is used in this position...!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>