### PR TITLE
Prevent duplicate shortcuts in preferences dialog

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -36,6 +36,7 @@
 #include "dlgTriggerEditor.h"
 #include "edbee/views/texteditorscrollarea.h"
 #include "edbee/models/textdocumentscopes.h"
+#include "KeyUnit.h"
 
 #include "pre_guard.h"
 #include <chrono>
@@ -51,7 +52,9 @@
 #include <QUiLoader>
 #include <QKeySequenceEdit>
 #include <QHBoxLayout>
-#include <QMessageBox>
+#include <QLocale>
+#include <QListWidgetItem>
+#include <QStringList>
 #include "../3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h"
 #include "post_guard.h"
 
@@ -1311,38 +1314,21 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                 candidateSequence = editedSequence;
             }
 
-            if (!candidateSequence.isEmpty()) {
-                const auto iteratorEnd = currentShortcuts.cend();
-                for (auto iterator = currentShortcuts.cbegin(); iterator != iteratorEnd; ++iterator) {
-                    if (iterator.key() == key) {
-                        continue;
-                    }
-                    if (*iterator.value() == candidateSequence) {
-                        sequenceEdit->setKeySequence(*sequence);
-                        const QString conflictingActionLabel = mudlet::self()->mpShortcutsManager->getLabel(iterator.key());
-                        const QString conflictingShortcutText = candidateSequence.toString(QKeySequence::NativeText);
-                        //: Message shown when the user tries to assign a shortcut that is already used by another action.
-                        QMessageBox::warning(this,
-                                             tr("Duplicate shortcut"),
-                                             tr("The shortcut %1 is already assigned to \"%2\". Please choose a different shortcut.")
-                                                     .arg(conflictingShortcutText, conflictingActionLabel));
-                        return;
-                    }
-                }
-            }
-
             QKeySequence newSequence = candidateSequence;
             sequenceEdit->setKeySequence(newSequence);
             sequence->swap(newSequence);
+            updateShortcutWarnings();
         });
         connect(this, &dlgProfilePreferences::signal_resetMainWindowShortcutsToDefaults, sequenceEdit, [=]() {
             sequenceEdit->setKeySequence(*mudlet::self()->mpShortcutsManager->getDefault(key));
             QKeySequence* newSequence = new QKeySequence(*mudlet::self()->mpShortcutsManager->getDefault(key));
             sequence->swap(*newSequence);
             delete newSequence;
+            updateShortcutWarnings();
         });
     }
 
+    updateShortcutWarnings();
 }
 
 void dlgProfilePreferences::disconnectHostRelatedControls()
@@ -4682,6 +4668,129 @@ bool dlgProfilePreferences::updateDisplayFont()
     config->endChanges();
 
     return true;
+}
+
+void dlgProfilePreferences::updateShortcutWarnings()
+{
+    if (!label_shortcutWarnings || !listWidget_shortcutWarnings) {
+        return;
+    }
+
+    listWidget_shortcutWarnings->clear();
+
+    QMap<QString, QStringList> sequenceAssignments;
+    QMap<QString, QKeySequence> sequenceLookup;
+
+    const auto iteratorEnd = currentShortcuts.cend();
+    for (auto iterator = currentShortcuts.cbegin(); iterator != iteratorEnd; ++iterator) {
+        const QKeySequence* sequencePointer = iterator.value();
+        if (!sequencePointer) {
+            continue;
+        }
+
+        const QKeySequence sequence = *sequencePointer;
+        if (sequence.isEmpty()) {
+            continue;
+        }
+
+        const QString portableText = sequence.toString(QKeySequence::PortableText);
+        sequenceAssignments[portableText].append(mudlet::self()->mpShortcutsManager->getLabel(iterator.key()));
+        sequenceLookup.insert(portableText, sequence);
+    }
+
+    QStringList warnings;
+
+    for (auto iterator = sequenceAssignments.cbegin(); iterator != sequenceAssignments.cend(); ++iterator) {
+        if (iterator.value().size() < 2) {
+            continue;
+        }
+
+        const QString sequenceText = sequenceLookup.value(iterator.key()).toString(QKeySequence::NativeText);
+        const QString actionList = QLocale().createSeparatedList(iterator.value());
+        //: Warning shown when multiple actions share the same shortcut.
+        warnings.append(tr("Shortcut %1 is assigned to multiple actions: %2.").arg(sequenceText, actionList));
+    }
+
+    if (mpHost) {
+        KeyUnit* keyUnit = mpHost->getKeyUnit();
+        if (keyUnit) {
+            QMap<QString, QStringList> tkeyAssignments;
+
+            const auto collectKeyBindings = [&](auto&& collect, TKey* key) -> void {
+                if (!key) {
+                    return;
+                }
+
+                auto* children = key->getChildrenList();
+                if (key->isFolder()) {
+                    if (children) {
+                        for (TKey* child : *children) {
+                            collect(collect, child);
+                        }
+                    }
+                    return;
+                }
+
+                if (!key->state() || !key->shouldBeActive() || !key->ancestorsActive() || key->isTemporary()) {
+                    if (children) {
+                        for (TKey* child : *children) {
+                            collect(collect, child);
+                        }
+                    }
+                    return;
+                }
+
+                const Qt::Key keyCode = key->getKeyCode();
+                if (keyCode != Qt::Key_unknown) {
+                    const Qt::KeyboardModifiers modifiers = key->getKeyModifiers();
+                    const QKeySequence sequence(static_cast<int>(modifiers) | keyCode);
+                    if (!sequence.isEmpty()) {
+                        const QString portableText = sequence.toString(QKeySequence::PortableText);
+                        QString bindingDisplay = key->getName();
+                        const QString bindingName = keyUnit->getKeyName(keyCode, modifiers);
+                        if (!bindingName.isEmpty()) {
+                            //: Shows the TKey binding name and its resolved shortcut text.
+                            bindingDisplay = tr("%1 (%2)").arg(bindingDisplay, bindingName);
+                        }
+                        tkeyAssignments[portableText].append(bindingDisplay);
+                    }
+                }
+
+                if (children) {
+                    for (TKey* child : *children) {
+                        collect(collect, child);
+                    }
+                }
+            };
+
+            const auto rootNodes = keyUnit->getKeyRootNodeList();
+            for (TKey* key : rootNodes) {
+                collectKeyBindings(collectKeyBindings, key);
+            }
+
+            for (auto iterator = sequenceAssignments.cbegin(); iterator != sequenceAssignments.cend(); ++iterator) {
+                const QString portableText = iterator.key();
+                if (!tkeyAssignments.contains(portableText)) {
+                    continue;
+                }
+
+                const QString sequenceText = sequenceLookup.value(portableText).toString(QKeySequence::NativeText);
+                const QString actionList = QLocale().createSeparatedList(iterator.value());
+                const QString keyList = QLocale().createSeparatedList(tkeyAssignments.value(portableText));
+                //: Warning shown when a shortcut also matches a TKey binding.
+                warnings.append(tr("Shortcut %1 assigned to %2 conflicts with key binding(s): %3.")
+                                    .arg(sequenceText, actionList, keyList));
+            }
+        }
+    }
+
+    label_shortcutWarnings->setVisible(!warnings.isEmpty());
+    listWidget_shortcutWarnings->setVisible(!warnings.isEmpty());
+
+    for (const QString& warning : warnings) {
+        auto* item = new QListWidgetItem(warning, listWidget_shortcutWarnings);
+        item->setFlags(Qt::ItemIsEnabled);
+    }
 }
 
 void dlgProfilePreferences::cancelShortcutCaptures()

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -56,6 +56,7 @@
 #include <QLocale>
 #include <QListWidgetItem>
 #include <QStringList>
+#include <QSet>
 #include "../3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h"
 #include "post_guard.h"
 
@@ -4732,6 +4733,26 @@ void dlgProfilePreferences::updateShortcutWarnings()
 
     QMap<QString, QStringList> sequenceAssignments;
     QMap<QString, QKeySequence> sequenceLookup;
+    QMap<QString, QStringList> unsupportedSequenceCombinations;
+
+    const QSet<Qt::Key> unsupportedKeys = []() {
+        QSet<Qt::Key> keys;
+        for (int digit = 0; digit <= 9; ++digit) {
+            keys.insert(static_cast<Qt::Key>(Qt::Key_0 + digit));
+        }
+        for (int letter = 0; letter < 26; ++letter) {
+            keys.insert(static_cast<Qt::Key>(Qt::Key_A + letter));
+        }
+        keys.insert(Qt::Key_Minus);
+        keys.insert(Qt::Key_Equal);
+        keys.insert(Qt::Key_Delete);
+        keys.insert(Qt::Key_Insert);
+        keys.insert(Qt::Key_Home);
+        keys.insert(Qt::Key_End);
+        keys.insert(Qt::Key_PageUp);
+        keys.insert(Qt::Key_PageDown);
+        return keys;
+    }();
 
     const auto iteratorEnd = currentShortcuts.cend();
     for (auto iterator = currentShortcuts.cbegin(); iterator != iteratorEnd; ++iterator) {
@@ -4752,6 +4773,39 @@ void dlgProfilePreferences::updateShortcutWarnings()
 
         sequenceAssignments[sequenceKey].append(mudlet::self()->mpShortcutsManager->getLabel(iterator.key()));
         sequenceLookup.insert(sequenceKey, sequence);
+
+        QStringList unsupportedCombinations;
+        const int combinationCount = sequence.count();
+        for (int index = 0; index < combinationCount; ++index) {
+            const QKeyCombination combination = sequence[index];
+            if (!combination.isValid()) {
+                break;
+            }
+
+            if (combination.keyboardModifiers() != Qt::NoModifier) {
+                continue;
+            }
+
+            const Qt::Key key = combination.key();
+            if (!unsupportedKeys.contains(key)) {
+                continue;
+            }
+
+            QString combinationText;
+            if (keyUnit) {
+                combinationText = keyUnit->getKeyName(key, combination.keyboardModifiers());
+            }
+            if (combinationText.isEmpty()) {
+                combinationText = QKeySequence(combination).toString(QKeySequence::NativeText);
+            }
+            if (!combinationText.isEmpty()) {
+                unsupportedCombinations.append(combinationText);
+            }
+        }
+
+        if (!unsupportedCombinations.isEmpty()) {
+            unsupportedSequenceCombinations.insert(sequenceKey, unsupportedCombinations);
+        }
     }
 
     QStringList warnings;
@@ -4767,8 +4821,23 @@ void dlgProfilePreferences::updateShortcutWarnings()
         warnings.append(tr("Shortcut %1 is assigned to multiple actions: %2.").arg(sequenceText, actionList));
     }
 
+    for (auto iterator = unsupportedSequenceCombinations.cbegin(); iterator != unsupportedSequenceCombinations.cend(); ++iterator) {
+        const QString sequenceKey = iterator.key();
+        const auto actionIterator = sequenceAssignments.constFind(sequenceKey);
+        if (actionIterator == sequenceAssignments.cend()) {
+            continue;
+        }
+
+        const QString actionList = QLocale().createSeparatedList(actionIterator.value());
+        const QString combinationList = QLocale().createSeparatedList(iterator.value());
+        //: Warning shown when a shortcut uses keys without modifiers that Mudlet cannot detect.
+        warnings.append(tr("Shortcut %1 assigned to %2 uses %3 without modifiers; these shortcuts will not work.")
+                            .arg(describeSequence(sequenceLookup.value(sequenceKey)), actionList, combinationList));
+    }
+
     if (keyUnit) {
         QMap<QString, QStringList> tkeyAssignments;
+        QMap<QString, QStringList> tempTkeyAssignments;
 
             const auto collectKeyBindings = [&](auto&& collect, TKey* key) -> void {
                 if (!key) {
@@ -4806,7 +4875,11 @@ void dlgProfilePreferences::updateShortcutWarnings()
                             //: Shows the TKey binding name and its resolved shortcut text.
                             bindingDisplay = tr("%1 (%2)").arg(bindingDisplay, bindingName);
                         }
-                        tkeyAssignments[sequenceKey].append(bindingDisplay);
+                        if (key->isTemporary()) {
+                            tempTkeyAssignments[sequenceKey].append(bindingDisplay);
+                        } else {
+                            tkeyAssignments[sequenceKey].append(bindingDisplay);
+                        }
                     }
                 }
 
@@ -4824,15 +4897,21 @@ void dlgProfilePreferences::updateShortcutWarnings()
 
         for (auto iterator = sequenceAssignments.cbegin(); iterator != sequenceAssignments.cend(); ++iterator) {
             const QString sequenceKey = iterator.key();
-            if (!tkeyAssignments.contains(sequenceKey)) {
-                continue;
+            if (tkeyAssignments.contains(sequenceKey)) {
+                const QString actionList = QLocale().createSeparatedList(iterator.value());
+                const QString keyList = QLocale().createSeparatedList(tkeyAssignments.value(sequenceKey));
+                //: Warning shown when a shortcut also matches a permanent key binding.
+                warnings.append(tr("Shortcut %1 assigned to %2 conflicts with key binding(s): %3.")
+                                    .arg(describeSequence(sequenceLookup.value(sequenceKey)), actionList, keyList));
             }
 
-            const QString actionList = QLocale().createSeparatedList(iterator.value());
-            const QString keyList = QLocale().createSeparatedList(tkeyAssignments.value(sequenceKey));
-            //: Warning shown when a shortcut also matches a TKey binding.
-            warnings.append(tr("Shortcut %1 assigned to %2 conflicts with key binding(s): %3.")
-                                .arg(describeSequence(sequenceLookup.value(sequenceKey)), actionList, keyList));
+            if (tempTkeyAssignments.contains(sequenceKey)) {
+                const QString actionList = QLocale().createSeparatedList(iterator.value());
+                const QString keyList = QLocale().createSeparatedList(tempTkeyAssignments.value(sequenceKey));
+                //: Warning shown when a shortcut also matches a script tempKey binding.
+                warnings.append(tr("Shortcut %1 assigned to %2 conflicts with tempKey binding(s) registered by scripts: %3.")
+                                    .arg(describeSequence(sequenceLookup.value(sequenceKey)), actionList, keyList));
+            }
         }
     }
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -50,6 +50,7 @@
 #include <QTableWidget>
 #include <QToolBar>
 #include <QUiLoader>
+#include <QKeyCombination>
 #include <QKeySequenceEdit>
 #include <QHBoxLayout>
 #include <QLocale>
@@ -4678,6 +4679,8 @@ void dlgProfilePreferences::updateShortcutWarnings()
 
     listWidget_shortcutWarnings->clear();
 
+    KeyUnit* keyUnit = mpHost ? mpHost->getKeyUnit() : nullptr;
+
     const auto makeSequenceKey = [](const QKeySequence& sequence) -> QString {
         if (sequence.isEmpty()) {
             return QString();
@@ -4686,13 +4689,45 @@ void dlgProfilePreferences::updateShortcutWarnings()
         QStringList parts;
         const int combinationCount = sequence.count();
         for (int index = 0; index < combinationCount; ++index) {
-            const int combination = sequence[index];
-            if (combination == 0) {
+            const QKeyCombination combination = sequence[index];
+            if (!combination.isValid()) {
                 break;
             }
-            parts.append(QString::number(combination));
+            parts.append(QString::number(combination.toCombined()));
         }
         return parts.join(u',');
+    };
+
+    const auto describeSequence = [&](const QKeySequence& sequence) -> QString {
+        if (sequence.isEmpty()) {
+            return QString();
+        }
+
+        QStringList combinationTexts;
+        const int combinationCount = sequence.count();
+        for (int index = 0; index < combinationCount; ++index) {
+            const QKeyCombination combination = sequence[index];
+            if (!combination.isValid()) {
+                break;
+            }
+
+            QString combinationText;
+            if (keyUnit) {
+                combinationText = keyUnit->getKeyName(combination.key(), combination.keyboardModifiers());
+            }
+            if (combinationText.isEmpty()) {
+                combinationText = QKeySequence(combination).toString(QKeySequence::NativeText);
+            }
+            combinationTexts.append(combinationText);
+        }
+
+        if (combinationTexts.isEmpty()) {
+            return sequence.toString(QKeySequence::NativeText);
+        }
+
+        //: Separates multiple key combinations in a shortcut description.
+        const QString separator = tr(", then ");
+        return combinationTexts.join(separator);
     };
 
     QMap<QString, QStringList> sequenceAssignments;
@@ -4726,16 +4761,14 @@ void dlgProfilePreferences::updateShortcutWarnings()
             continue;
         }
 
-        const QString sequenceText = sequenceLookup.value(iterator.key()).toString(QKeySequence::NativeText);
+        const QString sequenceText = describeSequence(sequenceLookup.value(iterator.key()));
         const QString actionList = QLocale().createSeparatedList(iterator.value());
         //: Warning shown when multiple actions share the same shortcut.
         warnings.append(tr("Shortcut %1 is assigned to multiple actions: %2.").arg(sequenceText, actionList));
     }
 
-    if (mpHost) {
-        KeyUnit* keyUnit = mpHost->getKeyUnit();
-        if (keyUnit) {
-            QMap<QString, QStringList> tkeyAssignments;
+    if (keyUnit) {
+        QMap<QString, QStringList> tkeyAssignments;
 
             const auto collectKeyBindings = [&](auto&& collect, TKey* key) -> void {
                 if (!key) {
@@ -4752,7 +4785,7 @@ void dlgProfilePreferences::updateShortcutWarnings()
                     return;
                 }
 
-                if (!key->state() || !key->shouldBeActive() || !key->ancestorsActive() || key->isTemporary()) {
+                if (!key->state() || !key->shouldBeActive() || !key->ancestorsActive()) {
                     if (children) {
                         for (TKey* child : *children) {
                             collect(collect, child);
@@ -4789,19 +4822,17 @@ void dlgProfilePreferences::updateShortcutWarnings()
                 collectKeyBindings(collectKeyBindings, key);
             }
 
-            for (auto iterator = sequenceAssignments.cbegin(); iterator != sequenceAssignments.cend(); ++iterator) {
-                const QString sequenceKey = iterator.key();
-                if (!tkeyAssignments.contains(sequenceKey)) {
-                    continue;
-                }
-
-                const QString sequenceText = sequenceLookup.value(sequenceKey).toString(QKeySequence::NativeText);
-                const QString actionList = QLocale().createSeparatedList(iterator.value());
-                const QString keyList = QLocale().createSeparatedList(tkeyAssignments.value(sequenceKey));
-                //: Warning shown when a shortcut also matches a TKey binding.
-                warnings.append(tr("Shortcut %1 assigned to %2 conflicts with key binding(s): %3.")
-                                    .arg(sequenceText, actionList, keyList));
+        for (auto iterator = sequenceAssignments.cbegin(); iterator != sequenceAssignments.cend(); ++iterator) {
+            const QString sequenceKey = iterator.key();
+            if (!tkeyAssignments.contains(sequenceKey)) {
+                continue;
             }
+
+            const QString actionList = QLocale().createSeparatedList(iterator.value());
+            const QString keyList = QLocale().createSeparatedList(tkeyAssignments.value(sequenceKey));
+            //: Warning shown when a shortcut also matches a TKey binding.
+            warnings.append(tr("Shortcut %1 assigned to %2 conflicts with key binding(s): %3.")
+                                .arg(describeSequence(sequenceLookup.value(sequenceKey)), actionList, keyList));
         }
     }
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -51,6 +51,7 @@
 #include <QUiLoader>
 #include <QKeySequenceEdit>
 #include <QHBoxLayout>
+#include <QMessageBox>
 #include "../3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h"
 #include "post_guard.h"
 
@@ -1301,17 +1302,38 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         gridLayout_groupBox_shortcuts->addWidget(new QLabel(mudlet::self()->mpShortcutsManager->getLabel(key)), floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 1);
         gridLayout_groupBox_shortcuts->addWidget(sequenceEdit, floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 2);
         shortcutsRow++;
-        connect(sequenceEdit, &QKeySequenceEdit::editingFinished, this, [=]() {
-            QKeySequence* newSequence = nullptr;
-            if (sequenceEdit->keySequence().isEmpty()
-                    || sequenceEdit->keySequence().matches(QKeySequence(Qt::Key_Escape))) {
-                newSequence = new QKeySequence();
+        connect(sequenceEdit, &QKeySequenceEdit::editingFinished, this, [=, this]() {
+            const QKeySequence editedSequence = sequenceEdit->keySequence();
+            QKeySequence candidateSequence;
+            if (editedSequence.isEmpty() || editedSequence.matches(QKeySequence(Qt::Key_Escape))) {
+                candidateSequence = QKeySequence();
             } else {
-                newSequence = new QKeySequence(sequenceEdit->keySequence());
+                candidateSequence = editedSequence;
             }
-            sequenceEdit->setKeySequence(*newSequence);
-            sequence->swap(*newSequence);
-            delete newSequence;
+
+            if (!candidateSequence.isEmpty()) {
+                const auto iteratorEnd = currentShortcuts.cend();
+                for (auto iterator = currentShortcuts.cbegin(); iterator != iteratorEnd; ++iterator) {
+                    if (iterator.key() == key) {
+                        continue;
+                    }
+                    if (*iterator.value() == candidateSequence) {
+                        sequenceEdit->setKeySequence(*sequence);
+                        const QString conflictingActionLabel = mudlet::self()->mpShortcutsManager->getLabel(iterator.key());
+                        const QString conflictingShortcutText = candidateSequence.toString(QKeySequence::NativeText);
+                        //: Message shown when the user tries to assign a shortcut that is already used by another action.
+                        QMessageBox::warning(this,
+                                             tr("Duplicate shortcut"),
+                                             tr("The shortcut %1 is already assigned to \"%2\". Please choose a different shortcut.")
+                                                     .arg(conflictingShortcutText, conflictingActionLabel));
+                        return;
+                    }
+                }
+            }
+
+            QKeySequence newSequence = candidateSequence;
+            sequenceEdit->setKeySequence(newSequence);
+            sequence->swap(newSequence);
         });
         connect(this, &dlgProfilePreferences::signal_resetMainWindowShortcutsToDefaults, sequenceEdit, [=]() {
             sequenceEdit->setKeySequence(*mudlet::self()->mpShortcutsManager->getDefault(key));

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -4678,6 +4678,23 @@ void dlgProfilePreferences::updateShortcutWarnings()
 
     listWidget_shortcutWarnings->clear();
 
+    const auto makeSequenceKey = [](const QKeySequence& sequence) -> QString {
+        if (sequence.isEmpty()) {
+            return QString();
+        }
+
+        QStringList parts;
+        const int combinationCount = sequence.count();
+        for (int index = 0; index < combinationCount; ++index) {
+            const int combination = sequence[index];
+            if (combination == 0) {
+                break;
+            }
+            parts.append(QString::number(combination));
+        }
+        return parts.join(u',');
+    };
+
     QMap<QString, QStringList> sequenceAssignments;
     QMap<QString, QKeySequence> sequenceLookup;
 
@@ -4693,9 +4710,13 @@ void dlgProfilePreferences::updateShortcutWarnings()
             continue;
         }
 
-        const QString portableText = sequence.toString(QKeySequence::PortableText);
-        sequenceAssignments[portableText].append(mudlet::self()->mpShortcutsManager->getLabel(iterator.key()));
-        sequenceLookup.insert(portableText, sequence);
+        const QString sequenceKey = makeSequenceKey(sequence);
+        if (sequenceKey.isEmpty()) {
+            continue;
+        }
+
+        sequenceAssignments[sequenceKey].append(mudlet::self()->mpShortcutsManager->getLabel(iterator.key()));
+        sequenceLookup.insert(sequenceKey, sequence);
     }
 
     QStringList warnings;
@@ -4744,15 +4765,15 @@ void dlgProfilePreferences::updateShortcutWarnings()
                 if (keyCode != Qt::Key_unknown) {
                     const Qt::KeyboardModifiers modifiers = key->getKeyModifiers();
                     const QKeySequence sequence(static_cast<int>(modifiers) | keyCode);
-                    if (!sequence.isEmpty()) {
-                        const QString portableText = sequence.toString(QKeySequence::PortableText);
+                    const QString sequenceKey = makeSequenceKey(sequence);
+                    if (!sequenceKey.isEmpty()) {
                         QString bindingDisplay = key->getName();
                         const QString bindingName = keyUnit->getKeyName(keyCode, modifiers);
                         if (!bindingName.isEmpty()) {
                             //: Shows the TKey binding name and its resolved shortcut text.
                             bindingDisplay = tr("%1 (%2)").arg(bindingDisplay, bindingName);
                         }
-                        tkeyAssignments[portableText].append(bindingDisplay);
+                        tkeyAssignments[sequenceKey].append(bindingDisplay);
                     }
                 }
 
@@ -4769,14 +4790,14 @@ void dlgProfilePreferences::updateShortcutWarnings()
             }
 
             for (auto iterator = sequenceAssignments.cbegin(); iterator != sequenceAssignments.cend(); ++iterator) {
-                const QString portableText = iterator.key();
-                if (!tkeyAssignments.contains(portableText)) {
+                const QString sequenceKey = iterator.key();
+                if (!tkeyAssignments.contains(sequenceKey)) {
                     continue;
                 }
 
-                const QString sequenceText = sequenceLookup.value(portableText).toString(QKeySequence::NativeText);
+                const QString sequenceText = sequenceLookup.value(sequenceKey).toString(QKeySequence::NativeText);
                 const QString actionList = QLocale().createSeparatedList(iterator.value());
-                const QString keyList = QLocale().createSeparatedList(tkeyAssignments.value(portableText));
+                const QString keyList = QLocale().createSeparatedList(tkeyAssignments.value(sequenceKey));
                 //: Warning shown when a shortcut also matches a TKey binding.
                 warnings.append(tr("Shortcut %1 assigned to %2 conflicts with key binding(s): %3.")
                                     .arg(sequenceText, actionList, keyList));

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -217,6 +217,7 @@ private:
     void fillOutMapHistory();
     bool updateDisplayFont();
     void cancelShortcutCaptures();
+    void updateShortcutWarnings();
 
 
     QPointer<Host> mpHost;

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -4000,6 +4000,35 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QLabel" name="label_shortcutWarnings">
+            <property name="visible">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Warnings</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QListWidget" name="listWidget_shortcutWarnings">
+            <property name="visible">
+             <bool>false</bool>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::FocusPolicy::NoFocus</enum>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::SelectionMode::NoSelection</enum>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
## Summary
- add duplicate shortcut detection to the preferences dialog shortcut editor
- notify the user when a shortcut conflicts with an existing action and keep the previous value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7476f3fec832aaab80b12e58c5234