### PR TITLE
Fix context menu room move sticking behavior

### DIFF
--- a/src/RoomMoveActivationHandler.cpp
+++ b/src/RoomMoveActivationHandler.cpp
@@ -101,6 +101,7 @@ bool RoomMoveActivationHandler::handle(T2DMap::MapInteractionContext& context)
         mMapWidget.mPopupMenu = false;
         mMapWidget.mPick = false;
         mMapWidget.mRoomBeingMoved = true;
+        mMapWidget.mRoomMoveViaContextMenu = false;
         mMapWidget.mMultiRect = QRect(0, 0, 0, 0);
         mMapWidget.mNewMoveAction = false;
         if (mMapWidget.mpMap && mMapWidget.mpMap->mpRoomDB) {
@@ -125,6 +126,7 @@ bool RoomMoveActivationHandler::handle(T2DMap::MapInteractionContext& context)
         mMapWidget.mPopupMenu = false;
         mMapWidget.setMouseTracking(false);
         mMapWidget.mRoomBeingMoved = false;
+        mMapWidget.mRoomMoveViaContextMenu = false;
         mMapWidget.mMultiRect = QRect(0, 0, 0, 0);
         mMapWidget.mHasRoomMoveLastMapPoint = false;
         context.isRoomBeingMoved = false;

--- a/src/RoomMoveDragHandler.cpp
+++ b/src/RoomMoveDragHandler.cpp
@@ -50,7 +50,7 @@ bool RoomMoveDragHandler::matches(const T2DMap::MapInteractionContext& context) 
         return false;
     }
 
-    if (!context.buttons.testFlag(Qt::LeftButton)) {
+    if (!context.buttons.testFlag(Qt::LeftButton) && !mMapWidget.mRoomMoveViaContextMenu) {
         return false;
     }
 
@@ -67,7 +67,7 @@ bool RoomMoveDragHandler::handle(T2DMap::MapInteractionContext& context)
         return false;
     }
 
-    if (!context.buttons.testFlag(Qt::LeftButton)) {
+    if (!context.buttons.testFlag(Qt::LeftButton) && !mMapWidget.mRoomMoveViaContextMenu) {
         return false;
     }
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3597,6 +3597,8 @@ void T2DMap::slot_moveRoom()
     mRoomBeingMoved = true;
     setMouseTracking(true);
     mNewMoveAction = true;
+    mRoomMoveViaContextMenu = true;
+    mHasRoomMoveLastMapPoint = false;
 }
 
 void T2DMap::slot_showPropertiesDialog()

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -204,6 +204,7 @@ public:
     bool mRoomBeingMoved = false;
     QPointF mRoomMoveLastMapPoint;
     bool mHasRoomMoveLastMapPoint = false;
+    bool mRoomMoveViaContextMenu = false;
     mutable QVector<int> mRoomPickCycleCandidates;
     mutable int mRoomPickCycleIndex = -1;
     mutable int mRoomPickCycleLastReturned = 0;


### PR DESCRIPTION
## Summary
- track when a room move originates from the context menu so the selection follows the cursor without holding the mouse button
- reset the context menu move state when the move begins via dragging or after the drop completes

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f772bf15e0832a98ecfb9952f966d4