### PR TITLE
Allow map interactions after closing context menu

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -360,6 +360,10 @@ bool T2DMap::eventFilter(QObject* watched, QEvent* event)
             auto* pressEvent = new QMouseEvent(QEvent::MouseButtonPress, localPosF, localPosF, globalPosF,
                 Qt::LeftButton, Qt::LeftButton, mouseEvent->modifiers());
             QCoreApplication::postEvent(this, pressEvent);
+
+            auto* releaseEvent = new QMouseEvent(QEvent::MouseButtonRelease, localPosF, localPosF, globalPosF,
+                Qt::LeftButton, Qt::NoButton, mouseEvent->modifiers());
+            QCoreApplication::postEvent(this, releaseEvent);
         }
 
         return true;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -135,6 +135,34 @@ std::optional<int> T2DMap::roomIdAtWidgetPosition(const QPoint& widgetPosition, 
     return std::nullopt;
 }
 
+bool T2DMap::hasLabelAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const
+{
+    if (!area) {
+        return false;
+    }
+
+    QMapIterator<int, TMapLabel> iterator(area->mMapLabels);
+    while (iterator.hasNext()) {
+        iterator.next();
+        const auto& mapLabel = iterator.value();
+        if (mapLabel.pos.z() != mMapCenterZ) {
+            continue;
+        }
+
+        const QRectF boundingRect(
+            mapLabel.pos.x() * mRoomWidth + mRX,
+            mapLabel.pos.y() * mRoomHeight * -1 + mRY,
+            mapLabel.clickSize.width(),
+            mapLabel.clickSize.height());
+
+        if (boundingRect.contains(widgetPosition)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void T2DMap::prepareSingleClickSelection(MapInteractionContext& context)
 {
     mMultiRect = QRect(context.widgetPosition, context.widgetPosition);
@@ -280,37 +308,64 @@ bool T2DMap::InteractionDispatcher::dispatch(MapInteractionContext& context) con
 
 bool T2DMap::eventFilter(QObject* watched, QEvent* event)
 {
-    if (mActiveContextMenu && event && event->type() == QEvent::MouseButtonPress) {
-        auto* mouseEvent = static_cast<QMouseEvent*>(event);
-        if (mouseEvent && mouseEvent->button() == Qt::RightButton) {
-            const QPoint globalPos = mouseEvent->globalPosition().toPoint();
-            const QPoint localPos = mapFromGlobal(globalPos);
-
-            if (rect().contains(localPos)) {
-                auto menu = mActiveContextMenu;
-                mActiveContextMenu.clear();
-
-                if (menu) {
-                    menu->close();
-                }
-
-                const QPointF localPosF(localPos);
-                const QPointF globalPosF(globalPos);
-
-                auto* pressEvent = new QMouseEvent(QEvent::MouseButtonPress, localPosF, localPosF, globalPosF,
-                    Qt::RightButton, Qt::RightButton, mouseEvent->modifiers());
-                auto* releaseEvent = new QMouseEvent(QEvent::MouseButtonRelease, localPosF, localPosF, globalPosF,
-                    Qt::RightButton, Qt::NoButton, mouseEvent->modifiers());
-
-                QCoreApplication::postEvent(this, pressEvent);
-                QCoreApplication::postEvent(this, releaseEvent);
-
-                return true;
-            }
-        }
+    if (!mActiveContextMenu || !event || event->type() != QEvent::MouseButtonPress) {
+        return QObject::eventFilter(watched, event);
     }
 
-    return QObject::eventFilter(watched, event);
+    auto* mouseEvent = static_cast<QMouseEvent*>(event);
+    if (!mouseEvent) {
+        return QObject::eventFilter(watched, event);
+    }
+
+    const QPoint globalPos = mouseEvent->globalPosition().toPoint();
+    const QPoint localPos = mapFromGlobal(globalPos);
+
+    if (!rect().contains(localPos)) {
+        return QObject::eventFilter(watched, event);
+    }
+
+    auto menu = mActiveContextMenu;
+    mActiveContextMenu.clear();
+    mPopupMenu = false;
+
+    if (menu) {
+        menu->close();
+    }
+
+    const QPointF localPosF(localPos);
+    const QPointF globalPosF(globalPos);
+
+    if (mouseEvent->button() == Qt::RightButton) {
+        auto* pressEvent = new QMouseEvent(QEvent::MouseButtonPress, localPosF, localPosF, globalPosF,
+            Qt::RightButton, Qt::RightButton, mouseEvent->modifiers());
+        auto* releaseEvent = new QMouseEvent(QEvent::MouseButtonRelease, localPosF, localPosF, globalPosF,
+            Qt::RightButton, Qt::NoButton, mouseEvent->modifiers());
+
+        QCoreApplication::postEvent(this, pressEvent);
+        QCoreApplication::postEvent(this, releaseEvent);
+
+        return true;
+    }
+
+    if (mouseEvent->button() == Qt::LeftButton) {
+        const TArea* area = (mpMap && mpMap->mpRoomDB) ? mpMap->mpRoomDB->getArea(mAreaID) : nullptr;
+        bool hasInteractiveItem = false;
+
+        if (area) {
+            hasInteractiveItem = roomIdAtWidgetPosition(localPos, area).has_value()
+                || hasLabelAtWidgetPosition(localPos, area);
+        }
+
+        if (hasInteractiveItem) {
+            auto* pressEvent = new QMouseEvent(QEvent::MouseButtonPress, localPosF, localPosF, globalPosF,
+                Qt::LeftButton, Qt::LeftButton, mouseEvent->modifiers());
+            QCoreApplication::postEvent(this, pressEvent);
+        }
+
+        return true;
+    }
+
+    return true;
 }
 
 const QString& key_icon_dialog_ok_apply = qsl(":/icons/dialog-ok-apply.png");

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -147,6 +147,7 @@ public:
     void prepareSingleClickSelection(MapInteractionContext& context);
     std::optional<int> roomIdAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const;
     void populateUserContextMenus(QMenu& menu);
+    bool hasLabelAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const;
 
     // Was getTopLeft() which returned an index into mMultiSelectionList but that
     // has been been changed to mMultiSelectionSet which cannot be accessed via


### PR DESCRIPTION
## Summary
- allow the 2D map to close an open context menu and re-dispatch left clicks on rooms or labels so they can be selected immediately
- leave the current selection unchanged when dismissing the menu with a left click on empty space
- factor out a helper that detects labels at the clicked position to support the new behavior

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f7772bd678832a870898dfdcb1114f