### PR TITLE
Fix custom line point actions remaining disabled

### DIFF
--- a/src/CustomLineEditHandler.cpp
+++ b/src/CustomLineEditHandler.cpp
@@ -61,6 +61,10 @@ bool CustomLineEditHandler::matches(const T2DMap::MapInteractionContext& context
     }
 
     if (eventType == QEvent::MouseMove) {
+        if (!(context.buttons & Qt::LeftButton)) {
+            return false;
+        }
+
         return mMapWidget.mCustomLineSelectedRoom != 0 && mMapWidget.mCustomLineSelectedPoint >= 0;
     }
 
@@ -186,6 +190,10 @@ bool CustomLineEditHandler::handleMousePress(T2DMap::MapInteractionContext& cont
 
 bool CustomLineEditHandler::handleMouseMove(T2DMap::MapInteractionContext& context)
 {
+    if (!(context.buttons & Qt::LeftButton)) {
+        return false;
+    }
+
     if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
         mMapWidget.mCustomLineSelectedPoint = -1;
         return false;
@@ -218,7 +226,6 @@ bool CustomLineEditHandler::handleMouseMove(T2DMap::MapInteractionContext& conte
 
 bool CustomLineEditHandler::handleMouseRelease()
 {
-    mMapWidget.mCustomLineSelectedPoint = -1;
     return false;
 }
 


### PR DESCRIPTION
## Summary
- require the left mouse button to stay pressed while dragging a custom line point
- keep the point selection after releasing the mouse so the context menu stays enabled

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68f7787fc344832a96931e78cf1280e0