### PR TITLE
Improve map context menu interactions

### DIFF
--- a/src/RoomContextMenuHandler.cpp
+++ b/src/RoomContextMenuHandler.cpp
@@ -104,6 +104,8 @@ bool RoomContextMenuHandler::handle(T2DMap::MapInteractionContext& context)
     const int previousSelectionSize = mMapWidget.mMultiSelectionSet.size();
 
     if (context.hasClickedRoom) {
+        mMapWidget.cancelContextMenuSelectionRestore();
+
         const bool isRoomAlreadySelected = mMapWidget.mMultiSelectionSet.contains(context.clickedRoomId);
 
         if (isRoomAlreadySelected) {
@@ -121,6 +123,8 @@ bool RoomContextMenuHandler::handle(T2DMap::MapInteractionContext& context)
             selectionChanged = true;
         }
     } else if (previousSelectionSize <= 1 && previousSelectionSize > 0) {
+        mMapWidget.storeSelectionBeforeContextMenu();
+
         mMapWidget.clearSelection();
         mMapWidget.mMultiSelectionSet.clear();
         mMapWidget.mMultiSelectionHighlightRoomId = 0;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -60,6 +60,7 @@
 #include <QMapIterator>
 #include <QMenu>
 #include <QStandardPaths>
+#include <QTimer>
 #include <QtEvents>
 #include <QtUiTools>
 #include "post_guard.h"
@@ -154,6 +155,10 @@ void T2DMap::prepareSingleClickSelection(MapInteractionContext& context)
     const auto clickedRoomId = roomIdAtWidgetPosition(context.widgetPosition, area);
     context.hasClickedRoom = clickedRoomId.has_value();
     context.clickedRoomId = clickedRoomId.value_or(0);
+
+    if (context.hasClickedRoom && context.button != Qt::RightButton) {
+        cancelContextMenuSelectionRestore();
+    }
 
     if (context.button == Qt::RightButton) {
         return;
@@ -251,12 +256,82 @@ void T2DMap::registerContextMenu(QMenu* menu)
     mActiveContextMenu = menu;
 
     QObject::connect(menu, &QMenu::aboutToHide, this, [this]() {
-        mActiveContextMenu.clear();
+        onContextMenuClosed();
     });
 
     QObject::connect(menu, &QObject::destroyed, this, [this]() {
-        mActiveContextMenu.clear();
+        onContextMenuClosed();
     });
+}
+
+void T2DMap::onContextMenuClosed()
+{
+    mActiveContextMenu.clear();
+
+    if (!mRestoreSelectionAfterContextMenu) {
+        clearContextMenuSelectionRestoreState();
+        return;
+    }
+
+    if (mContextMenuRestoreQueued) {
+        return;
+    }
+
+    mContextMenuRestoreQueued = true;
+
+    QTimer::singleShot(0, this, [this]() {
+        restoreSelectionAfterContextMenu();
+    });
+}
+
+void T2DMap::restoreSelectionAfterContextMenu()
+{
+    mContextMenuRestoreQueued = false;
+
+    if (!mRestoreSelectionAfterContextMenu || mCancelContextMenuSelectionRestore) {
+        clearContextMenuSelectionRestoreState();
+        return;
+    }
+
+    mMultiSelectionSet = mStoredSelectionBeforeContextMenu;
+    mMultiSelection = mStoredMultiSelectionStateBeforeContextMenu;
+    mMultiSelectionHighlightRoomId = mStoredSelectionHighlightBeforeContextMenu;
+
+    updateSelectionWidget();
+
+    clearContextMenuSelectionRestoreState();
+}
+
+void T2DMap::clearContextMenuSelectionRestoreState()
+{
+    mStoredSelectionBeforeContextMenu.clear();
+    mStoredSelectionHighlightBeforeContextMenu = 0;
+    mStoredMultiSelectionStateBeforeContextMenu = false;
+    mRestoreSelectionAfterContextMenu = false;
+    mCancelContextMenuSelectionRestore = false;
+    mContextMenuRestoreQueued = false;
+}
+
+void T2DMap::storeSelectionBeforeContextMenu()
+{
+    if (mMultiSelectionSet.isEmpty()) {
+        clearContextMenuSelectionRestoreState();
+        return;
+    }
+
+    mStoredSelectionBeforeContextMenu = mMultiSelectionSet;
+    mStoredSelectionHighlightBeforeContextMenu = mMultiSelectionHighlightRoomId;
+    mStoredMultiSelectionStateBeforeContextMenu = mMultiSelection;
+    mRestoreSelectionAfterContextMenu = true;
+    mCancelContextMenuSelectionRestore = false;
+    mContextMenuRestoreQueued = false;
+}
+
+void T2DMap::cancelContextMenuSelectionRestore()
+{
+    if (mRestoreSelectionAfterContextMenu) {
+        mCancelContextMenuSelectionRestore = true;
+    }
 }
 
 bool T2DMap::InteractionDispatcher::dispatch(MapInteractionContext& context) const
@@ -282,28 +357,33 @@ bool T2DMap::eventFilter(QObject* watched, QEvent* event)
 {
     if (mActiveContextMenu && event && event->type() == QEvent::MouseButtonPress) {
         auto* mouseEvent = static_cast<QMouseEvent*>(event);
-        if (mouseEvent && mouseEvent->button() == Qt::RightButton) {
+        if (mouseEvent) {
+            const Qt::MouseButton button = mouseEvent->button();
+            if (button != Qt::LeftButton && button != Qt::RightButton) {
+                return QObject::eventFilter(watched, event);
+            }
             const QPoint globalPos = mouseEvent->globalPosition().toPoint();
             const QPoint localPos = mapFromGlobal(globalPos);
 
             if (rect().contains(localPos)) {
-                auto menu = mActiveContextMenu;
-                mActiveContextMenu.clear();
-
-                if (menu) {
-                    menu->close();
-                }
-
                 const QPointF localPosF(localPos);
                 const QPointF globalPosF(globalPos);
 
+                const Qt::MouseButtons buttonState = static_cast<Qt::MouseButtons>(button);
+
                 auto* pressEvent = new QMouseEvent(QEvent::MouseButtonPress, localPosF, localPosF, globalPosF,
-                    Qt::RightButton, Qt::RightButton, mouseEvent->modifiers());
+                    button, buttonState, mouseEvent->modifiers());
                 auto* releaseEvent = new QMouseEvent(QEvent::MouseButtonRelease, localPosF, localPosF, globalPosF,
-                    Qt::RightButton, Qt::NoButton, mouseEvent->modifiers());
+                    button, Qt::NoButton, mouseEvent->modifiers());
 
                 QCoreApplication::postEvent(this, pressEvent);
                 QCoreApplication::postEvent(this, releaseEvent);
+
+                auto menu = mActiveContextMenu;
+                if (menu) {
+                    menu->close();
+                }
+                mActiveContextMenu.clear();
 
                 return true;
             }

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -38,6 +38,7 @@
 #include <QString>
 #include <QTreeWidget>
 #include <QWidget>
+#include <QSet>
 #include <QtConcurrent>
 #include "post_guard.h"
 
@@ -211,6 +212,12 @@ public:
     QRectF mMultiRect;
     bool mPopupMenu = false;
     QPointer<QMenu> mActiveContextMenu;
+    QSet<int> mStoredSelectionBeforeContextMenu;
+    int mStoredSelectionHighlightBeforeContextMenu = 0;
+    bool mStoredMultiSelectionStateBeforeContextMenu = false;
+    bool mRestoreSelectionAfterContextMenu = false;
+    bool mCancelContextMenuSelectionRestore = false;
+    bool mContextMenuRestoreQueued = false;
     QSet<int> mMultiSelectionSet;
     QSet<int> mMultiSelectionBaseSet;
     QSet<int> mMultiSelectionAnchorSet;
@@ -365,6 +372,11 @@ private:
     void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
     inline void drawDoor(QPainter&, const TRoom&, const QString&, const QLineF&);
     void updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea);
+    void storeSelectionBeforeContextMenu();
+    void cancelContextMenuSelectionRestore();
+    void onContextMenuClosed();
+    void restoreSelectionAfterContextMenu();
+    void clearContextMenuSelectionRestoreState();
 
     bool mDialogLock = false;
     struct ClickPosition {


### PR DESCRIPTION
## Summary
- allow left and right mouse presses to close an open map context menu and forward the click to the map so selection still happens
- track and temporarily clear room selection when right-clicking on the void, restoring it automatically once the context menu closes unless a new selection was made
- share the stored selection state across map context menu handlers and expose helpers for future interactions

## Testing
- not run (GUI feature)

------
https://chatgpt.com/codex/tasks/task_e_68f780145848832aaf7dffa56a354857