### PR TITLE
Fix T2DMap destructor for CustomLineSession

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -73,6 +73,8 @@
 // qsls cannot be shared so define a common instance to use when
 // there are multiple places where they are used within this file:
 
+T2DMap::~T2DMap() = default;
+
 // replacement parameter supplied at point of use:
 const QString& key_plain = qsl("%1");
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -76,6 +76,7 @@ class T2DMap : public QWidget
 public:
     Q_DISABLE_COPY(T2DMap)
     explicit T2DMap(QWidget* parent = nullptr);
+    ~T2DMap();
     std::pair<bool, QString> setMapZoom(const qreal zoom, const int areaId = 0);
     void init();
     void paintEvent(QPaintEvent*) override;


### PR DESCRIPTION
## Summary
- declare an explicit T2DMap destructor in the header
- define the destructor in the implementation file so CustomLineSession is a complete type

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f7dc771130832a88e481cf14c732f3