### PR TITLE
Add draggable exit creation handles to mapper

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,7 @@ set(mudlet_SRCS
     LabelInteractionHandler.cpp
     PanInteractionHandler.cpp
     RoomContextMenuHandler.cpp
+    RoomExitCreationHandler.cpp
     RoomMoveActivationHandler.cpp
     RoomMoveDragHandler.cpp
     SelectionRectangleHandler.cpp

--- a/src/RoomExitCreationHandler.cpp
+++ b/src/RoomExitCreationHandler.cpp
@@ -1,0 +1,93 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by OpenAI                                         *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "RoomExitCreationHandler.h"
+
+#include "TArea.h"
+#include "TRoomDB.h"
+
+#include "pre_guard.h"
+#include <QMouseEvent>
+#include <QtGlobal>
+#include "post_guard.h"
+
+RoomExitCreationHandler::RoomExitCreationHandler(T2DMap& mapWidget)
+: mMapWidget(mapWidget)
+{
+}
+
+bool RoomExitCreationHandler::matches(const T2DMap::MapInteractionContext& context) const
+{
+    if (!context.event || !mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return false;
+    }
+
+    switch (context.event->type()) {
+    case QEvent::MouseMove:
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseButtonRelease:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool RoomExitCreationHandler::handle(T2DMap::MapInteractionContext& context)
+{
+    if (!context.event || !mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return false;
+    }
+
+    switch (context.event->type()) {
+    case QEvent::MouseMove:
+        if (mMapWidget.mExitLinkDragActive) {
+            mMapWidget.updateExitLinkDrag(context.widgetPositionF, context.mapPoint);
+            return true;
+        }
+
+        if (context.buttons == Qt::NoButton) {
+            if (mMapWidget.mMapViewOnly) {
+                mMapWidget.resetExitHandleHover();
+            } else {
+                mMapWidget.updateExitHandleHover(context.widgetPositionF, context.area);
+            }
+        }
+        return false;
+    case QEvent::MouseButtonPress:
+        if (context.button == Qt::LeftButton && !mMapWidget.mMapViewOnly) {
+            if (mMapWidget.beginExitLinkDrag(context.widgetPositionF, context.mapPoint)) {
+                return true;
+            }
+        }
+        return false;
+    case QEvent::MouseButtonRelease:
+        if (context.button == Qt::LeftButton && mMapWidget.mExitLinkDragActive) {
+            mMapWidget.endExitLinkDrag();
+            if (!mMapWidget.mMapViewOnly) {
+                mMapWidget.updateExitHandleHover(context.widgetPositionF, context.area);
+            } else {
+                mMapWidget.resetExitHandleHover();
+            }
+            return true;
+        }
+        return false;
+    default:
+        return false;
+    }
+}

--- a/src/RoomExitCreationHandler.h
+++ b/src/RoomExitCreationHandler.h
@@ -1,0 +1,37 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by OpenAI                                         *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#ifndef MUDLET_ROOMEXITCREATIONHANDLER_H
+#define MUDLET_ROOMEXITCREATIONHANDLER_H
+
+#include "T2DMap.h"
+
+class RoomExitCreationHandler : public T2DMap::IInteractionHandler
+{
+public:
+    explicit RoomExitCreationHandler(T2DMap& mapWidget);
+
+    bool matches(const T2DMap::MapInteractionContext& context) const override;
+    bool handle(T2DMap::MapInteractionContext& context) override;
+
+private:
+    T2DMap& mMapWidget;
+};
+
+#endif // MUDLET_ROOMEXITCREATIONHANDLER_H

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -63,6 +63,7 @@
 #include <QStandardPaths>
 #include <QtEvents>
 #include <QtUiTools>
+#include <limits>
 #include "post_guard.h"
 
 #include "mapInfoContributorManager.h"
@@ -2951,8 +2952,73 @@ void T2DMap::updateExitLinkDrag(const QPointF& widgetPosition, const QPointF& ma
     const int candidateY = qRound(mapPoint.y());
     const int candidateZ = mExitLinkStartRoomZ;
 
+    const int reverseDirection = TMap::scmReverseDirections.value(mExitLinkStartDirection, DIR_OTHER);
+
     int newTargetRoomId = 0;
-    if (!area->getAreaRooms().isEmpty()) {
+    int newTargetDirection = 0;
+
+    if (reverseDirection >= DIR_NORTH && reverseDirection <= DIR_OUT) {
+        qreal bestDistanceSquared = std::numeric_limits<qreal>::max();
+        const qreal detectionScale = 1.35;
+
+        for (int dx = -1; dx <= 1; ++dx) {
+            for (int dy = -1; dy <= 1; ++dy) {
+                const QList<int> roomsAtPosition = area->getRoomsByPosition(candidateX + dx, candidateY + dy, candidateZ);
+                for (int roomId : roomsAtPosition) {
+                    if (roomId == mExitLinkStartRoomId) {
+                        continue;
+                    }
+
+                    TRoom* candidateRoom = mpMap->mpRoomDB->getRoom(roomId);
+                    if (!candidateRoom) {
+                        continue;
+                    }
+
+                    QPointF center;
+                    QSizeF halfSize;
+                    if (!calculateRoomVisualGeometry(*candidateRoom, *area, center, halfSize)) {
+                        continue;
+                    }
+
+                    const auto handles = buildExitHandlePositions(center, halfSize);
+                    if (handles.isEmpty()) {
+                        continue;
+                    }
+
+                    const qreal baseRadius = computeExitHandleRadius(halfSize);
+                    if (baseRadius <= 0.0) {
+                        continue;
+                    }
+
+                    const qreal detectionRadius = baseRadius * detectionScale;
+                    const qreal detectionRadiusSquared = detectionRadius * detectionRadius;
+
+                    for (const auto& handle : handles) {
+                        if (handle.direction != reverseDirection) {
+                            continue;
+                        }
+
+                        const QPointF delta = handle.position - widgetPosition;
+                        const qreal distanceSquared = QPointF::dotProduct(delta, delta);
+                        if (distanceSquared > detectionRadiusSquared) {
+                            continue;
+                        }
+
+                        if (distanceSquared < bestDistanceSquared) {
+                            bestDistanceSquared = distanceSquared;
+                            newTargetRoomId = roomId;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (newTargetRoomId > 0) {
+            newTargetDirection = reverseDirection;
+        }
+    }
+
+    if (newTargetRoomId <= 0 && !area->getAreaRooms().isEmpty()) {
         const QList<int> roomsAtPosition = area->getRoomsByPosition(candidateX, candidateY, candidateZ);
         for (int roomId : roomsAtPosition) {
             if (roomId == mExitLinkStartRoomId) {
@@ -2961,12 +3027,8 @@ void T2DMap::updateExitLinkDrag(const QPointF& widgetPosition, const QPointF& ma
             newTargetRoomId = roomId;
             break;
         }
-    }
 
-    int newTargetDirection = 0;
-    if (newTargetRoomId > 0) {
-        const int reverseDirection = TMap::scmReverseDirections.value(mExitLinkStartDirection, DIR_OTHER);
-        if (reverseDirection >= DIR_NORTH && reverseDirection <= DIR_OUT) {
+        if (newTargetRoomId > 0 && reverseDirection >= DIR_NORTH && reverseDirection <= DIR_OUT) {
             newTargetDirection = reverseDirection;
         }
     }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -37,6 +37,7 @@
 #include "LabelInteractionHandler.h"
 #include "PanInteractionHandler.h"
 #include "RoomContextMenuHandler.h"
+#include "RoomExitCreationHandler.h"
 #include "RoomMoveActivationHandler.h"
 #include "RoomMoveDragHandler.h"
 #include "SelectionRectangleHandler.h"
@@ -368,6 +369,9 @@ T2DMap::T2DMap(QWidget* parent)
     mRoomContextMenuHandler = std::make_unique<RoomContextMenuHandler>(*this);
     registerInteractionHandler(mRoomContextMenuHandler.get(), 340);
 
+    mRoomExitCreationHandler = std::make_unique<RoomExitCreationHandler>(*this);
+    registerInteractionHandler(mRoomExitCreationHandler.get(), 320);
+
     mRoomMoveActivationHandler = std::make_unique<RoomMoveActivationHandler>(*this);
     registerInteractionHandler(mRoomMoveActivationHandler.get(), 300);
 
@@ -382,6 +386,8 @@ T2DMap::T2DMap(QWidget* parent)
 
     mPanInteractionHandler = std::make_unique<PanInteractionHandler>(*this);
     registerInteractionHandler(mPanInteractionHandler.get(), 100);
+
+    setMouseTracking(true);
 }
 
 void T2DMap::init()
@@ -456,6 +462,9 @@ void T2DMap::switchArea(const QString& newAreaName)
     if (!pHost || !mpMap) {
         return;
     }
+
+    resetExitHandleHover();
+    clearExitLinkState();
 
     const int playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
     TRoom* pPlayerRoom = mpMap->mpRoomDB->getRoom(playerRoomId);
@@ -1820,6 +1829,8 @@ void T2DMap::paintEvent(QPaintEvent* e)
         painter.restore();
     }
 
+    drawExitCreationOverlay(painter, *pDrawnArea);
+
     // Draw the ("foreground") labels that are on the top of the map:
     itMapLabel.toFront();
     while (itMapLabel.hasNext()) {
@@ -2813,6 +2824,438 @@ void T2DMap::updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea)
     }
 }
 
+void T2DMap::updateExitHandleHover(const QPointF& widgetPosition, const TArea* area)
+{
+    if (mExitLinkDragActive) {
+        return;
+    }
+
+    const int previousRoomId = mHoveredRoomId;
+    const int previousDirection = mHoveredExitDirection;
+
+    int newRoomId = 0;
+    int newDirection = 0;
+
+    if (!mMapViewOnly && mpMap && mpMap->mpRoomDB && area) {
+        const auto roomId = roomIdAtWidgetPosition(widgetPosition.toPoint(), area);
+        if (roomId.has_value()) {
+            if (TRoom* room = mpMap->mpRoomDB->getRoom(roomId.value())) {
+                if (TArea* roomArea = mpMap->mpRoomDB->getArea(room->getArea())) {
+                    QPointF center;
+                    QSizeF halfSize;
+                    if (calculateRoomVisualGeometry(*room, *roomArea, center, halfSize)) {
+                        const auto handles = buildExitHandlePositions(center, halfSize);
+                        const qreal radius = computeExitHandleRadius(halfSize);
+                        const qreal radiusSquared = radius * radius;
+
+                        for (const auto& handle : handles) {
+                            const QPointF delta = handle.position - widgetPosition;
+                            const qreal distanceSquared = QPointF::dotProduct(delta, delta);
+                            if (distanceSquared <= radiusSquared) {
+                                newDirection = handle.direction;
+                                break;
+                            }
+                        }
+
+                        newRoomId = room->getId();
+                    }
+                }
+            }
+        }
+    }
+
+    mHoveredRoomId = newRoomId;
+    mHoveredExitDirection = newDirection;
+
+    if (previousRoomId != mHoveredRoomId || previousDirection != mHoveredExitDirection) {
+        update();
+    }
+}
+
+void T2DMap::resetExitHandleHover()
+{
+    if (mHoveredRoomId != 0 || mHoveredExitDirection != 0) {
+        mHoveredRoomId = 0;
+        mHoveredExitDirection = 0;
+        update();
+    }
+}
+
+bool T2DMap::beginExitLinkDrag(const QPointF& widgetPosition, const QPointF& mapPoint)
+{
+    if (mMapViewOnly || mExitLinkDragActive || !mpMap || !mpMap->mpRoomDB) {
+        return false;
+    }
+
+    const int startRoomId = mHoveredRoomId;
+    const int startDirection = mHoveredExitDirection;
+
+    if (startRoomId <= 0 || startDirection <= 0) {
+        return false;
+    }
+
+    TRoom* room = mpMap->mpRoomDB->getRoom(startRoomId);
+    if (!room) {
+        return false;
+    }
+
+    TArea* roomArea = mpMap->mpRoomDB->getArea(room->getArea());
+    if (!roomArea) {
+        return false;
+    }
+
+    QPointF center;
+    QSizeF halfSize;
+    if (!calculateRoomVisualGeometry(*room, *roomArea, center, halfSize)) {
+        return false;
+    }
+
+    mExitLinkDragActive = true;
+    mExitLinkStartRoomId = startRoomId;
+    mExitLinkStartDirection = startDirection;
+    mExitLinkStartRoomAreaId = room->getArea();
+    mExitLinkStartRoomZ = room->z();
+    mExitLinkCurrentPosition = widgetPosition;
+    mExitLinkTargetRoomId = 0;
+    mExitLinkTargetDirection = 0;
+
+    updateExitLinkDrag(widgetPosition, mapPoint);
+
+    return true;
+}
+
+void T2DMap::updateExitLinkDrag(const QPointF& widgetPosition, const QPointF& mapPoint)
+{
+    if (!mExitLinkDragActive) {
+        return;
+    }
+
+    mExitLinkCurrentPosition = widgetPosition;
+
+    if (!mpMap || !mpMap->mpRoomDB) {
+        mExitLinkTargetRoomId = 0;
+        mExitLinkTargetDirection = 0;
+        update();
+        return;
+    }
+
+    TArea* area = mpMap->mpRoomDB->getArea(mExitLinkStartRoomAreaId);
+    if (!area) {
+        mExitLinkTargetRoomId = 0;
+        mExitLinkTargetDirection = 0;
+        update();
+        return;
+    }
+
+    const int candidateX = qRound(mapPoint.x());
+    const int candidateY = qRound(mapPoint.y());
+    const int candidateZ = mExitLinkStartRoomZ;
+
+    int newTargetRoomId = 0;
+    if (!area->getAreaRooms().isEmpty()) {
+        const QList<int> roomsAtPosition = area->getRoomsByPosition(candidateX, candidateY, candidateZ);
+        for (int roomId : roomsAtPosition) {
+            if (roomId == mExitLinkStartRoomId) {
+                continue;
+            }
+            newTargetRoomId = roomId;
+            break;
+        }
+    }
+
+    int newTargetDirection = 0;
+    if (newTargetRoomId > 0) {
+        const int reverseDirection = TMap::scmReverseDirections.value(mExitLinkStartDirection, DIR_OTHER);
+        if (reverseDirection >= DIR_NORTH && reverseDirection <= DIR_OUT) {
+            newTargetDirection = reverseDirection;
+        }
+    }
+
+    mExitLinkTargetRoomId = newTargetRoomId;
+    mExitLinkTargetDirection = newTargetDirection;
+
+    update();
+}
+
+void T2DMap::endExitLinkDrag()
+{
+    if (!mExitLinkDragActive) {
+        return;
+    }
+
+    if (mpMap && mExitLinkTargetRoomId > 0 && mExitLinkStartRoomId > 0 && mExitLinkStartDirection > 0) {
+        mpMap->setExit(mExitLinkStartRoomId, mExitLinkTargetRoomId, mExitLinkStartDirection);
+
+        const int reverseDirection = TMap::scmReverseDirections.value(mExitLinkStartDirection, DIR_OTHER);
+        if (reverseDirection >= DIR_NORTH && reverseDirection <= DIR_OUT) {
+            mpMap->setExit(mExitLinkTargetRoomId, mExitLinkStartRoomId, reverseDirection);
+        }
+    }
+
+    clearExitLinkState();
+    update();
+}
+
+void T2DMap::drawExitCreationOverlay(QPainter& painter, const TArea& area)
+{
+    if (mMapViewOnly || mpHost.isNull() || !mpMap || !mpMap->mpRoomDB) {
+        return;
+    }
+
+    if (mHoveredRoomId > 0 && !mpMap->mpRoomDB->getRoom(mHoveredRoomId)) {
+        resetExitHandleHover();
+    }
+
+    if (mExitLinkStartRoomId > 0 && !mpMap->mpRoomDB->getRoom(mExitLinkStartRoomId)) {
+        clearExitLinkState();
+    }
+
+    if (mExitLinkTargetRoomId > 0 && !mpMap->mpRoomDB->getRoom(mExitLinkTargetRoomId)) {
+        mExitLinkTargetRoomId = 0;
+        mExitLinkTargetDirection = 0;
+    }
+
+    if (mExitLinkDragActive) {
+        drawExitLinkPreview(painter);
+    }
+
+    auto drawHandles = [&](int roomId, const QMap<int, QColor>& highlights, bool drawBase) {
+        if (roomId <= 0) {
+            return;
+        }
+        TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+        if (!room || room->getArea() != mAreaID) {
+            return;
+        }
+        TArea* roomArea = mpMap->mpRoomDB->getArea(room->getArea());
+        if (!roomArea) {
+            return;
+        }
+        drawExitHandlesForRoom(painter, *room, *roomArea, highlights, drawBase);
+    };
+
+    if (mExitLinkDragActive) {
+        QMap<int, QColor> startHighlights;
+        if (mExitLinkStartDirection > 0) {
+            QColor startColor = mpHost->mLightGreen_2;
+            startColor.setAlpha(230);
+            startHighlights.insert(mExitLinkStartDirection, startColor);
+        }
+        drawHandles(mExitLinkStartRoomId, startHighlights, true);
+
+        QMap<int, QColor> targetHighlights;
+        if (mExitLinkTargetDirection > 0) {
+            QColor targetColor = mpHost->mLightBlue_2;
+            targetColor.setAlpha(230);
+            targetHighlights.insert(mExitLinkTargetDirection, targetColor);
+        }
+        drawHandles(mExitLinkTargetRoomId, targetHighlights, true);
+    } else {
+        QMap<int, QColor> hoverHighlights;
+        if (mHoveredExitDirection > 0) {
+            QColor hoverColor = mpHost->mLightBlue_2;
+            hoverColor.setAlpha(230);
+            hoverHighlights.insert(mHoveredExitDirection, hoverColor);
+        }
+        drawHandles(mHoveredRoomId, hoverHighlights, true);
+    }
+}
+
+void T2DMap::drawExitLinkPreview(QPainter& painter)
+{
+    if (!mExitLinkDragActive || mpHost.isNull() || !mpMap || !mpMap->mpRoomDB) {
+        return;
+    }
+
+    TRoom* startRoom = mpMap->mpRoomDB->getRoom(mExitLinkStartRoomId);
+    if (!startRoom) {
+        return;
+    }
+
+    TArea* startArea = mpMap->mpRoomDB->getArea(startRoom->getArea());
+    if (!startArea) {
+        return;
+    }
+
+    QPointF startCenter;
+    QSizeF startHalfSize;
+    if (!calculateRoomVisualGeometry(*startRoom, *startArea, startCenter, startHalfSize)) {
+        return;
+    }
+
+    const auto startHandles = buildExitHandlePositions(startCenter, startHalfSize);
+    QPointF startPoint = startCenter;
+    for (const auto& handle : startHandles) {
+        if (handle.direction == mExitLinkStartDirection) {
+            startPoint = handle.position;
+            break;
+        }
+    }
+
+    QPointF endPoint = mExitLinkCurrentPosition;
+
+    if (mExitLinkTargetRoomId > 0) {
+        if (TRoom* targetRoom = mpMap->mpRoomDB->getRoom(mExitLinkTargetRoomId)) {
+            if (TArea* targetArea = mpMap->mpRoomDB->getArea(targetRoom->getArea())) {
+                QPointF targetCenter;
+                QSizeF targetHalfSize;
+                if (calculateRoomVisualGeometry(*targetRoom, *targetArea, targetCenter, targetHalfSize)) {
+                    if (mExitLinkTargetDirection > 0) {
+                        const auto targetHandles = buildExitHandlePositions(targetCenter, targetHalfSize);
+                        for (const auto& handle : targetHandles) {
+                            if (handle.direction == mExitLinkTargetDirection) {
+                                endPoint = handle.position;
+                                break;
+                            }
+                        }
+                    } else {
+                        endPoint = targetCenter;
+                    }
+                }
+            }
+        }
+    }
+
+    QPen previewPen(mpHost->mLightBlue_2);
+    previewPen.setWidthF(qBound<qreal>(1.5, static_cast<qreal>(mRoomWidth) * 0.1, 4.0));
+    previewPen.setCapStyle(Qt::RoundCap);
+    previewPen.setJoinStyle(Qt::RoundJoin);
+    previewPen.setCosmetic(true);
+
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(previewPen);
+    painter.drawLine(startPoint, endPoint);
+    painter.restore();
+}
+
+void T2DMap::drawExitHandlesForRoom(QPainter& painter, const TRoom& room, const TArea& area, const QMap<int, QColor>& highlightColors, bool drawBaseHandles) const
+{
+    if (mpHost.isNull()) {
+        return;
+    }
+
+    QPointF center;
+    QSizeF halfSize;
+    if (!calculateRoomVisualGeometry(room, area, center, halfSize)) {
+        return;
+    }
+
+    const auto handles = buildExitHandlePositions(center, halfSize);
+    if (handles.isEmpty()) {
+        return;
+    }
+
+    const qreal baseRadius = computeExitHandleRadius(halfSize);
+    if (baseRadius <= 0.0) {
+        return;
+    }
+
+    QColor baseFill = mpHost->mRoomBorderColor;
+    baseFill.setAlpha(180);
+    QColor baseOutline = baseFill.darker(150);
+    baseOutline.setAlpha(220);
+
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    for (const auto& handle : handles) {
+        QColor fillColor = baseFill;
+        QColor outlineColor = baseOutline;
+        qreal radius = baseRadius;
+
+        if (highlightColors.contains(handle.direction)) {
+            QColor highlightColor = highlightColors.value(handle.direction);
+            if (!highlightColor.isValid()) {
+                highlightColor = baseFill;
+            }
+            fillColor = highlightColor;
+            QColor highlightOutline = highlightColor.darker(150);
+            highlightOutline.setAlpha(255);
+            outlineColor = highlightOutline;
+            radius *= 1.2;
+        } else if (!drawBaseHandles) {
+            continue;
+        }
+
+        QRectF ellipse(handle.position.x() - radius,
+                       handle.position.y() - radius,
+                       radius * 2.0,
+                       radius * 2.0);
+
+        painter.setPen(QPen(outlineColor, 1.0));
+        painter.setBrush(fillColor);
+        painter.drawEllipse(ellipse);
+    }
+
+    painter.restore();
+}
+
+QVector<T2DMap::ExitHandleData> T2DMap::buildExitHandlePositions(const QPointF& center, const QSizeF& halfSize) const
+{
+    QVector<ExitHandleData> handles;
+    handles.reserve(8);
+
+    const qreal halfWidth = halfSize.width();
+    const qreal halfHeight = halfSize.height();
+
+    handles.append({DIR_NORTH, QPointF(center.x(), center.y() - halfHeight)});
+    handles.append({DIR_SOUTH, QPointF(center.x(), center.y() + halfHeight)});
+    handles.append({DIR_EAST, QPointF(center.x() + halfWidth, center.y())});
+    handles.append({DIR_WEST, QPointF(center.x() - halfWidth, center.y())});
+    handles.append({DIR_NORTHEAST, QPointF(center.x() + halfWidth, center.y() - halfHeight)});
+    handles.append({DIR_NORTHWEST, QPointF(center.x() - halfWidth, center.y() - halfHeight)});
+    handles.append({DIR_SOUTHEAST, QPointF(center.x() + halfWidth, center.y() + halfHeight)});
+    handles.append({DIR_SOUTHWEST, QPointF(center.x() - halfWidth, center.y() + halfHeight)});
+
+    return handles;
+}
+
+bool T2DMap::calculateRoomVisualGeometry(const TRoom& room, const TArea& area, QPointF& center, QSizeF& halfSize) const
+{
+    const float fx = ((xspan / 2.0f) - mMapCenterX) * mRoomWidth;
+    const float fy = ((yspan / 2.0f) - mMapCenterY) * mRoomHeight;
+
+    const float rx = static_cast<float>(room.x()) * mRoomWidth + fx;
+    const float ry = static_cast<float>(room.y()) * -1 * mRoomHeight + fy;
+
+    center = QPointF(rx, ry);
+
+    qreal width = area.gridMode ? static_cast<qreal>(mRoomWidth) : static_cast<qreal>(mRoomWidth) * rSize;
+    qreal height = area.gridMode ? static_cast<qreal>(mRoomHeight) : static_cast<qreal>(mRoomHeight) * rSize;
+
+    if (mBubbleMode) {
+        const qreal diameter = static_cast<qreal>(mRoomWidth) * rSize;
+        width = diameter;
+        height = diameter;
+    }
+
+    halfSize = QSizeF(width / 2.0, height / 2.0);
+    return halfSize.width() > 0.0 && halfSize.height() > 0.0;
+}
+
+qreal T2DMap::computeExitHandleRadius(const QSizeF& halfSize) const
+{
+    const qreal minDimension = qMin(halfSize.width(), halfSize.height());
+    if (qFuzzyIsNull(minDimension)) {
+        return 0.0;
+    }
+
+    return qBound<qreal>(4.0, minDimension * 0.6, 12.0);
+}
+
+void T2DMap::clearExitLinkState()
+{
+    mExitLinkDragActive = false;
+    mExitLinkStartRoomId = 0;
+    mExitLinkStartDirection = 0;
+    mExitLinkStartRoomAreaId = 0;
+    mExitLinkStartRoomZ = 0;
+    mExitLinkTargetRoomId = 0;
+    mExitLinkTargetDirection = 0;
+    mExitLinkCurrentPosition = QPointF();
+}
+
 void T2DMap::mouseReleaseEvent(QMouseEvent* event)
 {
     if (!mpMap) {
@@ -3344,6 +3787,8 @@ void T2DMap::slot_toggleMapViewOnly()
         mapModeEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mpHost->raiseEvent(mapModeEvent);
 
+        resetExitHandleHover();
+        clearExitLinkState();
         update();
     }
 }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2952,70 +2952,71 @@ void T2DMap::updateExitLinkDrag(const QPointF& widgetPosition, const QPointF& ma
     const int candidateY = qRound(mapPoint.y());
     const int candidateZ = mExitLinkStartRoomZ;
 
-    const int reverseDirection = TMap::scmReverseDirections.value(mExitLinkStartDirection, DIR_OTHER);
-
     int newTargetRoomId = 0;
     int newTargetDirection = 0;
 
-    if (reverseDirection >= DIR_NORTH && reverseDirection <= DIR_OUT) {
-        qreal bestDistanceSquared = std::numeric_limits<qreal>::max();
-        const qreal detectionScale = 1.35;
+    qreal bestDistanceSquared = std::numeric_limits<qreal>::max();
+    qreal bestWithinRadiusSquared = std::numeric_limits<qreal>::max();
+    int bestWithinRadiusRoomId = 0;
+    int bestWithinRadiusDirection = 0;
 
-        for (int dx = -1; dx <= 1; ++dx) {
-            for (int dy = -1; dy <= 1; ++dy) {
-                const QList<int> roomsAtPosition = area->getRoomsByPosition(candidateX + dx, candidateY + dy, candidateZ);
-                for (int roomId : roomsAtPosition) {
-                    if (roomId == mExitLinkStartRoomId) {
-                        continue;
+    const qreal detectionScale = 1.35;
+
+    for (int dx = -1; dx <= 1; ++dx) {
+        for (int dy = -1; dy <= 1; ++dy) {
+            const QList<int> roomsAtPosition = area->getRoomsByPosition(candidateX + dx, candidateY + dy, candidateZ);
+            for (int roomId : roomsAtPosition) {
+                if (roomId == mExitLinkStartRoomId) {
+                    continue;
+                }
+
+                TRoom* candidateRoom = mpMap->mpRoomDB->getRoom(roomId);
+                if (!candidateRoom) {
+                    continue;
+                }
+
+                QPointF center;
+                QSizeF halfSize;
+                if (!calculateRoomVisualGeometry(*candidateRoom, *area, center, halfSize)) {
+                    continue;
+                }
+
+                const auto handles = buildExitHandlePositions(center, halfSize);
+                if (handles.isEmpty()) {
+                    continue;
+                }
+
+                const qreal baseRadius = computeExitHandleRadius(halfSize);
+                if (baseRadius <= 0.0) {
+                    continue;
+                }
+
+                const qreal detectionRadius = baseRadius * detectionScale;
+                const qreal detectionRadiusSquared = detectionRadius * detectionRadius;
+
+                for (const auto& handle : handles) {
+                    const QPointF delta = handle.position - widgetPosition;
+                    const qreal distanceSquared = QPointF::dotProduct(delta, delta);
+
+                    if (distanceSquared < bestDistanceSquared) {
+                        bestDistanceSquared = distanceSquared;
+                        newTargetRoomId = roomId;
+                        newTargetDirection = handle.direction;
                     }
 
-                    TRoom* candidateRoom = mpMap->mpRoomDB->getRoom(roomId);
-                    if (!candidateRoom) {
-                        continue;
-                    }
-
-                    QPointF center;
-                    QSizeF halfSize;
-                    if (!calculateRoomVisualGeometry(*candidateRoom, *area, center, halfSize)) {
-                        continue;
-                    }
-
-                    const auto handles = buildExitHandlePositions(center, halfSize);
-                    if (handles.isEmpty()) {
-                        continue;
-                    }
-
-                    const qreal baseRadius = computeExitHandleRadius(halfSize);
-                    if (baseRadius <= 0.0) {
-                        continue;
-                    }
-
-                    const qreal detectionRadius = baseRadius * detectionScale;
-                    const qreal detectionRadiusSquared = detectionRadius * detectionRadius;
-
-                    for (const auto& handle : handles) {
-                        if (handle.direction != reverseDirection) {
-                            continue;
-                        }
-
-                        const QPointF delta = handle.position - widgetPosition;
-                        const qreal distanceSquared = QPointF::dotProduct(delta, delta);
-                        if (distanceSquared > detectionRadiusSquared) {
-                            continue;
-                        }
-
-                        if (distanceSquared < bestDistanceSquared) {
-                            bestDistanceSquared = distanceSquared;
-                            newTargetRoomId = roomId;
-                        }
+                    if (distanceSquared <= detectionRadiusSquared && distanceSquared < bestWithinRadiusSquared) {
+                        bestWithinRadiusSquared = distanceSquared;
+                        bestWithinRadiusRoomId = roomId;
+                        bestWithinRadiusDirection = handle.direction;
                     }
                 }
             }
         }
+    }
 
-        if (newTargetRoomId > 0) {
-            newTargetDirection = reverseDirection;
-        }
+    if (bestWithinRadiusRoomId > 0) {
+        newTargetRoomId = bestWithinRadiusRoomId;
+        newTargetDirection = bestWithinRadiusDirection;
     }
 
     if (newTargetRoomId <= 0 && !area->getAreaRooms().isEmpty()) {
@@ -3028,8 +3029,23 @@ void T2DMap::updateExitLinkDrag(const QPointF& widgetPosition, const QPointF& ma
             break;
         }
 
-        if (newTargetRoomId > 0 && reverseDirection >= DIR_NORTH && reverseDirection <= DIR_OUT) {
-            newTargetDirection = reverseDirection;
+        if (newTargetRoomId > 0) {
+            if (TRoom* candidateRoom = mpMap->mpRoomDB->getRoom(newTargetRoomId)) {
+                QPointF center;
+                QSizeF halfSize;
+                if (calculateRoomVisualGeometry(*candidateRoom, *area, center, halfSize)) {
+                    const auto handles = buildExitHandlePositions(center, halfSize);
+                    qreal fallbackBestDistance = std::numeric_limits<qreal>::max();
+                    for (const auto& handle : handles) {
+                        const QPointF delta = handle.position - widgetPosition;
+                        const qreal distanceSquared = QPointF::dotProduct(delta, delta);
+                        if (distanceSquared < fallbackBestDistance) {
+                            fallbackBestDistance = distanceSquared;
+                            newTargetDirection = handle.direction;
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -3047,10 +3063,8 @@ void T2DMap::endExitLinkDrag()
 
     if (mpMap && mExitLinkTargetRoomId > 0 && mExitLinkStartRoomId > 0 && mExitLinkStartDirection > 0) {
         mpMap->setExit(mExitLinkStartRoomId, mExitLinkTargetRoomId, mExitLinkStartDirection);
-
-        const int reverseDirection = TMap::scmReverseDirections.value(mExitLinkStartDirection, DIR_OTHER);
-        if (reverseDirection >= DIR_NORTH && reverseDirection <= DIR_OUT) {
-            mpMap->setExit(mExitLinkTargetRoomId, mExitLinkStartRoomId, reverseDirection);
+        if (mExitLinkTargetDirection >= DIR_NORTH && mExitLinkTargetDirection <= DIR_OUT) {
+            mpMap->setExit(mExitLinkTargetRoomId, mExitLinkStartRoomId, mExitLinkTargetDirection);
         }
     }
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -34,6 +34,7 @@
 #include <QFont>
 #include <QFutureWatcher>
 #include <QPixmap>
+#include <QVector>
 #include <QPointer>
 #include <QString>
 #include <QTreeWidget>
@@ -91,6 +92,7 @@ public:
     friend class CustomLineEditHandler;
     friend class LabelInteractionHandler;
     friend class RoomContextMenuHandler;
+    friend class RoomExitCreationHandler;
     friend class RoomMoveDragHandler;
     friend class SelectionRectangleHandler;
 
@@ -346,6 +348,7 @@ private:
     std::unique_ptr<IInteractionHandler> mCustomLineEditContextMenuHandler;
     std::unique_ptr<IInteractionHandler> mCustomLineEditInteractionHandler;
     std::unique_ptr<IInteractionHandler> mRoomContextMenuHandler;
+    std::unique_ptr<IInteractionHandler> mRoomExitCreationHandler;
     std::unique_ptr<IInteractionHandler> mRoomMoveActivationHandler;
     std::unique_ptr<IInteractionHandler> mRoomMoveDragHandler;
     std::unique_ptr<IInteractionHandler> mSelectionRectangleInteractionHandler;
@@ -365,6 +368,25 @@ private:
     void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
     inline void drawDoor(QPainter&, const TRoom&, const QString&, const QLineF&);
     void updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea);
+
+    struct ExitHandleData
+    {
+        int direction = 0;
+        QPointF position;
+    };
+
+    void updateExitHandleHover(const QPointF& widgetPosition, const TArea* area);
+    void resetExitHandleHover();
+    bool beginExitLinkDrag(const QPointF& widgetPosition, const QPointF& mapPoint);
+    void updateExitLinkDrag(const QPointF& widgetPosition, const QPointF& mapPoint);
+    void endExitLinkDrag();
+    void drawExitCreationOverlay(QPainter& painter, const TArea& area);
+    void drawExitLinkPreview(QPainter& painter);
+    void drawExitHandlesForRoom(QPainter& painter, const TRoom& room, const TArea& area, const QMap<int, QColor>& highlightColors, bool drawBaseHandles) const;
+    QVector<ExitHandleData> buildExitHandlePositions(const QPointF& center, const QSizeF& halfSize) const;
+    bool calculateRoomVisualGeometry(const TRoom& room, const TArea& area, QPointF& center, QSizeF& halfSize) const;
+    qreal computeExitHandleRadius(const QSizeF& halfSize) const;
+    void clearExitLinkState();
 
     bool mDialogLock = false;
     struct ClickPosition {
@@ -398,6 +420,17 @@ private:
     dlgRoomProperties* mpDlgRoomProperties = nullptr;
     dlgMapLabel* mpDlgMapLabel = nullptr;
     // Track the area last viewed so we can raise an event when it changes,
+
+    int mHoveredRoomId = 0;
+    int mHoveredExitDirection = 0;
+    bool mExitLinkDragActive = false;
+    int mExitLinkStartRoomId = 0;
+    int mExitLinkStartDirection = 0;
+    int mExitLinkStartRoomAreaId = 0;
+    int mExitLinkStartRoomZ = 0;
+    int mExitLinkTargetRoomId = 0;
+    int mExitLinkTargetDirection = 0;
+    QPointF mExitLinkCurrentPosition;
     // initialised to an invalid area that is different to the one that mAreaID
     // is initialised to - so that the xyzoom gets read for the first area that
     // is shown - because the value of these two are different:


### PR DESCRIPTION
## Summary
- add a RoomExitCreationHandler to surface directional handles while editing the map
- render exit creation overlays and preview lines in T2DMap to support drag-to-link exits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7fe963cf0832a99c7afbb1c5762bc